### PR TITLE
Require Cabal 1.8+

### DIFF
--- a/time-units.cabal
+++ b/time-units.cabal
@@ -1,7 +1,7 @@
 Name: time-units
 Version: 1.0.0
 Build-Type: Simple
-Cabal-Version: >= 1.6
+Cabal-Version: >= 1.8
 License: BSD3
 License-File: LICENSE
 Author: Adam Wick <awick@uhsure.com>


### PR DESCRIPTION
Fixes the warning:
```
Warning: time-units.cabal:22:32: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```